### PR TITLE
Update merqury to 1.3+galaxy4 (v2.0.7)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,6 @@ authors:
     given-names: "Anna"
     orcid: "https://orcid.org/0000-0002-9906-0673"
 title: "Genome assessment post assembly"
-version: 2.0.6
+version: 2.0.7
 doi: 10.48546/WORKFLOWHUB.WORKFLOW.403.7
-date-released: 2023-11-23
+date-released: 2026-04-17

--- a/Galaxy-Workflow-Genome_assessment_post_assembly.ga
+++ b/Galaxy-Workflow-Genome_assessment_post_assembly.ga
@@ -393,7 +393,7 @@
         },
         "8": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/merqury/merqury/1.3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/merqury/merqury/1.3+galaxy4",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -445,15 +445,15 @@
                 "top": 533.8817141507601
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/merqury/merqury/1.3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/merqury/merqury/1.3+galaxy4",
             "tool_shed_repository": {
-                "changeset_revision": "9d79beb19ac3",
+                "changeset_revision": "eb7b00ec347d",
                 "name": "merqury",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"label\": \"output_merqury\", \"mode\": {\"options\": \"default\", \"__current_case__\": 0, \"meryldb_F1\": {\"__class__\": \"ConnectedValue\"}, \"assembly_options\": {\"number_assemblies\": \"one\", \"__current_case__\": 0, \"assembly_01\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3",
+            "tool_version": "1.3+galaxy4",
             "type": "tool",
             "uuid": "31643288-e958-42dd-94a1-5919d29ebd8f",
             "when": null,

--- a/change_log.md
+++ b/change_log.md
@@ -1,7 +1,7 @@
 # Change log
 
 ## v2.0.7
-- Updated merqury from version 1.3 to 1.3+galaxy4 (version 1.3 is no longer available on the Galaxy toolshed)
+- Updated merqury tool version string from `1.3` to `1.3+galaxy4` — the bare `1.3` wrapper is no longer available on the Galaxy toolshed, causing a validation error on import. The underlying merqury version is unchanged.
 
 ## v2.0.6
 - Updated label for reads (assembly reads not raw reads)

--- a/change_log.md
+++ b/change_log.md
@@ -1,5 +1,8 @@
 # Change log
 
+## v2.0.7
+- Updated merqury from version 1.3 to 1.3+galaxy4 (version 1.3 is no longer available on the Galaxy toolshed)
+
 ## v2.0.6
 - Updated label for reads (assembly reads not raw reads)
 - Added workflow report text into the workflow annotation, as it sometimes disappears


### PR DESCRIPTION
## Summary
- The workflow specifies merqury tool ID with version `1.3` (no Galaxy wrapper suffix), which is no longer available on the toolshed — causing a validation error on import
- Updated the tool version string to `1.3+galaxy4`, which is the current available wrapper for merqury 1.3 on Galaxy Australia
- The underlying merqury version is unchanged (still 1.3); only the Galaxy wrapper suffix has been added
- No other changes to workflow structure or logic

## Test plan
- [ ] Import workflow on Galaxy Australia and confirm it opens without validation errors
- [ ] Run workflow with test data to confirm merqury step completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)